### PR TITLE
[DS-182] Allow to map a String doppler field as Billing or Shipping Field.

### DIFF
--- a/src/admin/class-doppler-for-woocommerce-admin.php
+++ b/src/admin/class-doppler-for-woocommerce-admin.php
@@ -282,36 +282,6 @@ class Doppler_For_Woocommerce_Admin {
 	}
 
 	/**
-	 * Check connection status.
-	 */
-	/**
-	 * Check connection status. Doesnt check against 
-	 * API anymore to reduce requests.
-	 */
-	/*
-	public function check_connection_status() {
-
-		$options = get_option('dplr_settings');
-
-		if ( ! is_admin() ||  empty($options) ) {
-			return false;
-		}
-
-		isset($options['dplr_option_useraccount'])? $user = $options['dplr_option_useraccount'] : '';
-		isset($options['dplr_option_apikey'])? 		$key = $options['dplr_option_apikey'] : '';
-
-		if( !empty($user) && !empty($key) ){
-			if(empty($this->doppler_service->config['crendentials'])){
-				$this->doppler_service->setCredentials(array('api_key' => $key, 'user_account' => $user));
-			}
-			return true;
-		}
-
-		return false;
-
-	}*/
-
-	/**
 	 * Get the customer's fields.
 	 */
 	public function get_checkout_fields() {
@@ -665,6 +635,10 @@ class Doppler_For_Woocommerce_Admin {
 					foreach($fieldgroup as $fieldname=>$v){
 						$f = $key.'_'.$fieldname;
 						if( isset($fields_map[$f]) && $fields_map[$f] != '' ){
+							if( $f === 'billing_country' || $f === 'shipping_country' ){
+								//If is mapped doppler field is string translate this to the full country name.
+								if ($fields_map[$f] != 'COUNTRY') $v = $this->get_country_from_code($v);
+							}
 							$fields[] = array('name'=>$fields_map[$f], 'value'=>$v);
 						}
 					}
@@ -714,6 +688,13 @@ class Doppler_For_Woocommerce_Admin {
 		return array_map(function($item){
 			return sanitize_text_field($item);
 		},$list);
+	}
+
+	private function get_country_from_code( $code ) {
+		if(!class_exists('WC_Countries')) return $code;
+		$c = new WC_Countries();
+		$countries = $c->get_countries();
+		return !empty($countries[$code])? $countries[$code] : $code;
 	}
 
 }

--- a/src/admin/class-doppler-for-woocommerce-admin.php
+++ b/src/admin/class-doppler-for-woocommerce-admin.php
@@ -417,7 +417,8 @@ class Doppler_For_Woocommerce_Admin {
 	}
 
 	/**
-	 * After registering from my-account page
+	 * Subscribe customer after registering
+	 * from my-account.
 	 */
 	public function dprwoo_after_register( $user_id ){
 		$list_id = get_option('dplr_subscribers_list')['contacts'];
@@ -430,8 +431,8 @@ class Doppler_For_Woocommerce_Admin {
 	}
 	
 	/**
-	 * Envía subscriptor a la lista de compradores
-	 * cuando una orden pasa a estado "completo".
+	 * Send subscriptor to buyers List
+	 * after order status is completed.
 	 */
 	public function dplrwoo_order_completed( $order_id, $old_status, $new_status, $instance ) {
 		if( $new_status == "completed" ) {
@@ -444,9 +445,9 @@ class Doppler_For_Woocommerce_Admin {
 	}
 
 	/**
-	 * Envía a la lista de contactos los datos del cliente
-	 * en el checkout.
-	 * Sólo para WC > 3.0
+	 * Subscribe user to a Contact List
+	 * after checking out.
+	 * Only WC > 3.0.
 	 */
 	public function dplrwoo_customer_checkout_success( $order_id ) {
 		$list_id = get_option('dplr_subscribers_list')['contacts'];
@@ -562,7 +563,10 @@ class Doppler_For_Woocommerce_Admin {
 
 	}
 
-	public function dplrwoo_clear_buyers_list(){
+	/**
+	 * Clear buyers and contacts List.
+	 */
+	public function dplrwoo_clear_lists(){
 		update_option( 'dplr_subscribers_list', array('buyers','') );
 		update_option( 'dplr_subscribers_list', array('contacts','') );
 		echo '1';
@@ -592,11 +596,17 @@ class Doppler_For_Woocommerce_Admin {
 		echo json_encode(array('contacts'=>$c_count, 'buyers'=>$b_count));
 		wp_die();
 	}
-
+	
+	/**
+	 * Validates on site tracking code.
+	 */
 	public function validate_tracking_code($code){
 		return preg_match("/(<|%3C)script[\s\S]*?(>|%3E)[\s\S]*?(<|%3C)(\/|%2F)script[\s\S]*?(>|%3E)/", $code);
 	}
-
+	
+	/**
+	 * Sanitize on site tracking pasted code.
+	 */
 	public function sanitize_tracking_code($code){
 		//Is valid to save empty value in this case.
 		if($code === '') return $code;
@@ -620,7 +630,6 @@ class Doppler_For_Woocommerce_Admin {
 		}
 	}
 	
-
 	/**
 	 * Get the mapped fields of a given order.
 	 */
@@ -678,18 +687,29 @@ class Doppler_For_Woocommerce_Admin {
 	}
 
 	/**
-	 * Sanitize list array
+	 * Sanitize lists ID array.
 	 */
 	private function sanitize_subscribers_list( $list ) {
 		return array_filter($list,'is_numeric');
 	}
 
+	/**
+	 * Sanitizes an array of text strings.
+	 * Used to sanizie map fields array.
+	 */
 	private function sanitize_text_array( $list ) {
 		return array_map(function($item){
 			return sanitize_text_field($item);
 		},$list);
 	}
 
+	/**
+	 * Get country string from a given country code.
+	 * Used to send country to doppler only if the mapped
+	 * Doppler field for billing country or shipping country
+	 * is a string. If for any reason the code isn't found
+	 * in WC countries array, just return the code.
+	 */
 	private function get_country_from_code( $code ) {
 		if(!class_exists('WC_Countries')) return $code;
 		$c = new WC_Countries();

--- a/src/admin/class-doppler-for-woocommerce-admin.php
+++ b/src/admin/class-doppler-for-woocommerce-admin.php
@@ -695,7 +695,7 @@ class Doppler_For_Woocommerce_Admin {
 
 	/**
 	 * Sanitizes an array of text strings.
-	 * Used to sanizie map fields array.
+	 * Used to sanitize map fields array.
 	 */
 	private function sanitize_text_array( $list ) {
 		return array_map(function($item){

--- a/src/admin/js/doppler-for-woocommerce-admin.js
+++ b/src/admin/js/doppler-for-woocommerce-admin.js
@@ -127,7 +127,7 @@
 			var button = $(this);
 			button.attr('disabled','disabled').addClass("button--loading");
 			var data = {
-				action: 'dplrwoo_ajax_clear_buyers_list',
+				action: 'dplrwoo_ajax_clear_lists',
 			}
 			$.post( ajaxurl, data, function(response){
 				if(response=='1') {

--- a/src/includes/class-doppler-for-woocommerce.php
+++ b/src/includes/class-doppler-for-woocommerce.php
@@ -173,7 +173,7 @@ class Doppler_For_Woocommerce {
 		$this->loader->add_action( 'wp_ajax_dplrwoo_ajax_save_list', $plugin_admin, 'dplrwoo_save_list' );
 		$this->loader->add_action( 'wp_ajax_dplrwoo_ajax_synch', $plugin_admin, 'dplrwoo_synch' );
 		$this->loader->add_action( 'wp_ajax_dplrwoo_ajax_create_lists' , $plugin_admin, 'dplrwoo_create_default_lists' );
-		$this->loader->add_action( 'wp_ajax_dplrwoo_ajax_clear_buyers_list', $plugin_admin, 'dplrwoo_clear_buyers_list');
+		$this->loader->add_action( 'wp_ajax_dplrwoo_ajax_clear_lists', $plugin_admin, 'dplrwoo_clear_lists');
 		$this->loader->add_action( 'woocommerce_created_customer', $plugin_admin, 'dplrwoo_created_customer', 10, 3);
 		$this->loader->add_action( 'woocommerce_thankyou', $plugin_admin, 'dplrwoo_customer_checkout_success' );
 		$this->loader->add_action( 'woocommerce_order_status_changed', $plugin_admin, 'dplrwoo_order_completed', 10, 4 );


### PR DESCRIPTION
Is WooCommerce is posible that the user need more than one country field to be mapped. If he wants to map a billing field country and a shipping field country he can't map COUNTRY default field in both of these fields. That's why we allow to map a string field with WC country type fields. This way the user coud select COUNTRY as billing field, and another string custom filed (ie. "país") as shipping field.

We detect if this is the case (a billing or shipping field wanting to map a string field) and translate the country code to sabe the country as string (ie Argentina instead of AR).