### PR TITLE
Doppler For WooCommerce: Check account change

### DIFF
--- a/src/admin/class-doppler-for-woocommerce-admin.php
+++ b/src/admin/class-doppler-for-woocommerce-admin.php
@@ -753,7 +753,7 @@ class Doppler_For_Woocommerce_Admin {
 	 * @return object
 	 */
 	public function dplrwoo_verify_keys() {
-		if(!empty(get_option('dplrwoo_consumer_secret'))){
+		if(!empty(get_option('dplrwoo_api_connected'))){
 			wp_send_json_success();
 		}else{
 			$options = get_option('dplr_settings');
@@ -768,7 +768,10 @@ class Doppler_For_Woocommerce_Admin {
 
 				$response = $app_connect->connect();
 				if($response['response']['code'] === 200){
-					update_option('dplrwoo_consumer_secret', 'on');
+					update_option('dplrwoo_api_connected', array(
+						'account' => $options['dplr_option_useraccount'],
+						'status' => 'on'
+					));
 					wp_send_json_success();
 				}
 			}		

--- a/src/admin/class-doppler-for-woocommerce-admin.php
+++ b/src/admin/class-doppler-for-woocommerce-admin.php
@@ -74,6 +74,7 @@ class Doppler_For_Woocommerce_Admin {
 		$this->required_doppler_version = '2.1.5';
 		$this->origin = $this->set_origin();
 		$this->set_credentials();
+		$this->check_current_account();
 	}
 
 	/**
@@ -213,6 +214,20 @@ class Doppler_For_Woocommerce_Admin {
 			'api_key' => $options['dplr_option_apikey'], 
 			'user_account' => $options['dplr_option_useraccount'])
 		);
+	}
+
+	private function check_current_account() {
+		$options = get_option('dplr_settings');
+		$status = get_option('dplrwoo_api_connected');
+		if( !empty($status) && !empty($options) && 
+			!$this->compare_accounts($options['dplr_option_apikey'], $status['account']) )
+			{
+				
+			}
+	}
+
+	private function compare_accounts($doppler_account, $connected_account) {
+		return $doppler_account == $connected_account;
 	}
 
 	/**

--- a/src/admin/js/doppler-for-woocommerce-admin.js
+++ b/src/admin/js/doppler-for-woocommerce-admin.js
@@ -65,22 +65,6 @@
 			);
 		});
 
-		/*
-		syncListsButton.click(function(e){
-			e.preventDefault();
-
-			var buyersList = buyersListSelect.val();
-			var contactsList = contactListSelect.val();
-			$(this).attr('disabled','disabled').addClass("button--loading");
-			$("#dplr-settings-text").html(ObjWCStr.Synchronizing);
-			$.when(createDefaultList(buyersList, 'buyers'), createDefaultList(contactsList, 'contacts')).done(function(bl,cl){
-				$.when(synchBuyers(bl),synchContacts(cl)).done(function(){
-					listsForm.submit();
-				});
-			});
-		});
-		*/
-
 		var synchBuyers = function(buyersList){
 			if(buyersList==='') return false;
 			$.post( ajaxurl, {action:'dplrwoo_ajax_synch',list_type: 'buyers', list_id: buyersList});

--- a/src/doppler-for-woocommerce.php
+++ b/src/doppler-for-woocommerce.php
@@ -39,7 +39,8 @@ define( 'DOPPLER_FOR_WOOCOMMERCE_URL', plugin_dir_url(__FILE__));
 define( 'DOPPLER_FOR_WOOCOMMERCE_PLUGIN', plugin_basename( __FILE__ ));
 if(!defined( 'DOPPLER_PLUGINS_PATH' )) define('DOPPLER_PLUGINS_PATH', plugin_dir_path(__DIR__));
 if(!defined( 'DOPPLER_ABANDONED_CART_TABLE')) define('DOPPLER_ABANDONED_CART_TABLE', 'dplrwoo_abandoned_cart');
-if(!defined( 'DOPPLER_WOO_API_URL' )) define('DOPPLER_WOO_API_URL', 'https://restapi.fromdoppler.com/');
+//if(!defined( 'DOPPLER_WOO_API_URL' )) define('DOPPLER_WOO_API_URL', 'https://restapi.fromdoppler.com/');
+if(!defined( 'DOPPLER_WOO_API_URL' )) define('DOPPLER_WOO_API_URL', 'http://newapiqa.fromdoppler.net/');
 if(!defined( 'DOPPLER_FOR_WOOCOMMERCE_ORIGIN' )) define('DOPPLER_FOR_WOOCOMMERCE_ORIGIN', 'WooCommerce');
 
 

--- a/src/includes/class-doppler-for-woocommerce-activator.php
+++ b/src/includes/class-doppler-for-woocommerce-activator.php
@@ -65,16 +65,16 @@ class Doppler_For_Woocommerce_Activator {
 		/**
 		 * Doppler App Integration.
 		 * 
-		 * If plugin in installed for the 1st time (dplrwoo_consumer_secret is empty)
+		 * If plugin in installed for the 1st time (dplrwoo_api_connected is empty)
 		 * we ignore app integration becouse it will be performed on first sync.
 		 * 
-		 * If for some reason dplrwoo_consumer_secret has a value, it means plugin was
+		 * If for some reason dplrwoo_api_connected has a value, it means plugin was
 		 * deactivated and re-activated. On deactivation Integration was DELETED, so we
 		 * are goint to re-activate and regenerate the keys.
 		 * 
 		 */
 		$options = get_option('dplr_settings');
-		if(!empty(get_option('dplrwoo_consumer_secret'))){
+		if(!empty(get_option('dplrwoo_api_connected'))){
 			$DopplerAppConnect = new Doppler_For_WooCommerce_App_Connect(
 				$options['dplr_option_useraccount'], $options['dplr_option_apikey'],
 				DOPPLER_WOO_API_URL, DOPPLER_FOR_WOOCOMMERCE_ORIGIN

--- a/src/includes/class-doppler-for-woocommerce-admin-notice.php
+++ b/src/includes/class-doppler-for-woocommerce-admin-notice.php
@@ -20,7 +20,7 @@ class Doppler_For_WooCommerce_Admin_Notice
     
         if ($message) {
             echo "<div class='notice {$noticeLevel} is-dismissible'><p>{$message}</p></div>";
-            delete_option(self::NOTICE_FIELD);
+            delete_option(static::NOTICE_FIELD);
         }
     }
 

--- a/src/includes/class-doppler-for-woocommerce-admin-notice.php
+++ b/src/includes/class-doppler-for-woocommerce-admin-notice.php
@@ -13,14 +13,14 @@ class Doppler_For_WooCommerce_Admin_Notice
 {
     const NOTICE_FIELD = 'dplrwoo_notice_field';
 
-    public function display_admin_notice() {
-        $option      = get_option(static::NOTICE_FIELD);
+    public static function display_admin_notice() {
+        $option      = get_option(self::NOTICE_FIELD);
         $message     = isset($option['notice_message']) ? $option['notice_message'] : false;
         $noticeLevel = !empty($option['notice_class']) ? $option['notice_class'] : 'notice-error';
     
         if ($message) {
             echo "<div class='notice {$noticeLevel} is-dismissible'><p>{$message}</p></div>";
-            delete_option(static::NOTICE_FIELD);
+            delete_option(self::NOTICE_FIELD);
         }
     }
 
@@ -41,7 +41,7 @@ class Doppler_For_WooCommerce_Admin_Notice
     }
     
     protected static function update_option_field( $notice_message, $notice_class){
-        update_option(  static::NOTICE_FIELD, 
+        update_option(  self::NOTICE_FIELD, 
                         array(  'notice_message' => $notice_message,
                                 'notice_class' => $notice_class)
         );

--- a/src/includes/class-doppler-for-woocommerce-app-connect.php
+++ b/src/includes/class-doppler-for-woocommerce-app-connect.php
@@ -40,7 +40,7 @@ class Doppler_For_WooCommerce_App_Connect {
     }
 
     private function get_api_key() {
-		return (static::DEBUG_MODE)? '884E71335D719C8F7A37A84F48D7EE6F' : $this->api_key;		
+		return $this->api_key;		
     }
 
     private function get_api_url() {
@@ -87,10 +87,6 @@ class Doppler_For_WooCommerce_App_Connect {
 		if(empty($account) || empty($api_url)) return false;
 		
 		$url = $api_url . '/'. $account. '/' . static::INTEGRATION;
-		
-		if(static::DEBUG_MODE){
-			$url = 'http://newapiqa.fromdoppler.net/accounts/mariofabianblanc@gmail.com/integrations/magento';
-		}
 
 		 return wp_remote_request($url, array(
 			'method' => $method,

--- a/src/includes/class-doppler-for-woocommerce-app-connect.php
+++ b/src/includes/class-doppler-for-woocommerce-app-connect.php
@@ -86,7 +86,7 @@ class Doppler_For_WooCommerce_App_Connect {
 		
 		if(empty($account) || empty($api_url)) return false;
 		
-		$url = $api_url . '/'. $account. '/' . static::INTEGRATION;
+		$url = $api_url . '/'. $account. '/' . self::INTEGRATION;
 
 		 return wp_remote_request($url, array(
 			'method' => $method,

--- a/src/includes/class-doppler-for-woocommerce-deactivator.php
+++ b/src/includes/class-doppler-for-woocommerce-deactivator.php
@@ -39,7 +39,7 @@ class Doppler_For_Woocommerce_Deactivator {
 		 * and shows message.
 		 */
 		$options = get_option('dplr_settings');
-		$has_consumer_secret = get_option('dplrwoo_consumer_secret');
+		$has_consumer_secret = get_option('dplrwoo_api_connected');
 
 		if( empty($options['dplr_option_useraccount']) || empty($options['dplr_option_apikey']) ||
 			empty($has_consumer_secret) ) return false;

--- a/src/includes/class-doppler-for-woocommerce-deactivator.php
+++ b/src/includes/class-doppler-for-woocommerce-deactivator.php
@@ -32,7 +32,7 @@ class Doppler_For_Woocommerce_Deactivator {
 	 * @since    1.0.0
 	 */
 	public static function deactivate() {
-
+		
 		/**
 		 * On deactivation delete integration with APP.
 		 * If APP couldn't delete stops deactivation

--- a/src/uninstall.php
+++ b/src/uninstall.php
@@ -38,7 +38,7 @@ if( $_REQUEST['plugin'] === ( plugin_basename( __DIR__ ) . '/doppler-for-woocomm
 		'dplrwoo_mapping',
 		'dplrwoo_use_hub',
 		'dplrwoo_version',
-		'dplrwoo_consumer_secret',
+		'dplrwoo_api_connected',
 		'dplrwoo_notice_field'
 	);
 	


### PR DESCRIPTION
- Plugin checks if logged account matches the associated account of the API integration. If it doesn't disconnects the integration, regenerate WC keys and re-connects the integration. 