### PR TITLE
[DOI-616] Test plugin with Wordpress v6.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,8 @@ Contributors: fromdoppler
 Donate link: https://www.fromdoppler.com/
 Tags: email marketing woocommerce
 Requires at least: 4.9
-Tested up to: 5.9.2
-Stable tag: 1.1.4
+Tested up to: 6.0.0
+Stable tag: 1.1.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 3.3.2


### PR DESCRIPTION
The plugin works fine with wordpress v6.0, I'm updating the readme file to remove version warnings in the wordpress platform.
This changes are already pushed into the svn.